### PR TITLE
Add .gitignore for Terraform state and kubeconfigs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Terraform state and modules
+.terraform/
+*.tfstate
+*.tfstate.*
+
+# Crash logs
+crash.log
+
+# Terraform dependency lock file
+.terraform.lock.hcl
+
+# Generated kubeconfig files
+**/kubeconfig*


### PR DESCRIPTION
## Summary
- ignore Terraform directories and state files
- ignore crash logs and Terraform lock file
- ignore generated kubeconfig files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686be7fb866c8325bbe79ab9d9b8b285