### PR TITLE
Add Terraform CI workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,33 @@
+name: Terraform Checks
+
+on:
+  push:
+    paths:
+      - 'environments/dev/**'
+      - '.github/workflows/terraform.yml'
+  pull_request:
+    paths:
+      - 'environments/dev/**'
+      - '.github/workflows/terraform.yml'
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+
+      - name: Terraform Format
+        working-directory: environments/dev
+        run: terraform fmt -check
+
+      - name: Terraform Init
+        working-directory: environments/dev
+        run: terraform init -backend=false
+
+      - name: Terraform Validate
+        working-directory: environments/dev
+        run: terraform validate


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Terraform checks

## Testing
- `terraform fmt -check environments/dev`
- `terraform init -backend=false` *(fails: could not connect to registry)*
- `terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_6879625671548325b05205f478dbdad5