### PR TITLE
Update Kubernetes version to 1.29

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -66,7 +66,7 @@ module "gke" {
 
   # Basic cluster configuration
   regional_cluster   = true
-  kubernetes_version = "1.28"
+  kubernetes_version = "1.29"
   release_channel    = "REGULAR"
 
   # Default node pool

--- a/modules/aks/README.md
+++ b/modules/aks/README.md
@@ -51,7 +51,7 @@ module "aks" {
   # Recommended/Optional
   node_resource_group_name = "my-aks-nodes"
   dns_prefix               = "prod-aks"
-  kubernetes_version       = "1.28.3"
+  kubernetes_version       = "1.29.0"
   sku_tier                 = "Paid"
   enable_private_cluster   = true
   api_server_authorized_ip_ranges = ["10.0.0.0/8", "203.0.113.0/24"]

--- a/modules/gke/README.md
+++ b/modules/gke/README.md
@@ -65,7 +65,7 @@ module "gke" {
   # Cluster configuration
   regional_cluster   = true
   node_locations     = ["us-central1-a", "us-central1-b", "us-central1-c"]
-  kubernetes_version = "1.28"
+  kubernetes_version = "1.29"
   release_channel    = "REGULAR"
 
   # Networking


### PR DESCRIPTION
## Summary
- bump GKE cluster version in the dev environment to 1.29
- update docs examples to use Kubernetes 1.29

## Testing
- `terraform fmt -check -recursive` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68796254f888832586436bc6a89f9f8b