### PR TITLE
Fix GKE subnet output usage

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -62,7 +62,7 @@ module "gke" {
   cluster_name = "dev-gke"
   region       = var.gcp_region
   network      = module.networking.gcp_network_name
-  subnetwork   = module.networking.gcp_subnetwork_names[0]
+  subnetwork   = module.networking.subnet_names[0]
 
   # Basic cluster configuration
   regional_cluster   = true


### PR DESCRIPTION
## Summary
- update GKE module reference to use `subnet_names` output
- run `terraform fmt` on dev environment

## Testing
- `terraform fmt environments/dev/main.tf`


------
https://chatgpt.com/codex/tasks/task_e_687a4078b16883259991eeeaec3e9050