### PR TITLE
Update provider versions

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -19,6 +19,20 @@
 #==============================================================================
 terraform {
   required_version = ">= 1.0.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.50.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.50.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.42.0"
+    }
+  }
 }
 
 

--- a/modules/iam/README.md
+++ b/modules/iam/README.md
@@ -34,8 +34,8 @@ This Terraform module creates and manages identity and access management (IAM) r
 | aws | ~> 5.98.0 |
 | azuread | ~> 3.4.0 |
 | azurerm | ~> 4.30.0 |
-| google | ~> 6.37.0 |
-| kubernetes | ~> 2.37.1 |
+| google | ~> 6.50.0 |
+| kubernetes | ~> 2.42.0 |
 | kubectl | ~> 1.19.0 |
 
 ## Usage

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -32,11 +32,11 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.37.0"
+      version = "~> 6.50.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.37.1"
+      version = "~> 2.42.0"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"

--- a/modules/networking/README.md
+++ b/modules/networking/README.md
@@ -60,7 +60,7 @@ module "network" {
 | terraform | >= 1.0.0 |
 | aws | ~> 5.98.0 |
 | azurerm | ~> 3.95.0 |
-| google | ~> 6.37.0 |
+| google | ~> 6.50.0 |
 
 ## Input Variables
 

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -25,7 +25,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.37.0"
+      version = "~> 6.50.0"
     }
   }
   required_version = ">= 1.0.0"

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -14,7 +14,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.37.0"
+      version = "~> 6.50.0"
     }
   }
   required_version = ">= 1.0.0"


### PR DESCRIPTION
## Summary
- update provider versions in modules and docs
- specify required providers in dev environment

## Testing
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_687a45c48004832586f9a2259021b83a