### PR TITLE
Fix provider versions

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -22,15 +22,15 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.50.0"
+      version = "~> 5.20.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 6.50.0"
+      version = "~> 5.20.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.42.0"
+      version = "~> 2.29.0"
     }
   }
 }

--- a/modules/aks/main.tf
+++ b/modules/aks/main.tf
@@ -23,15 +23,15 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.45.0"  # Latest stable Azure provider at time of creation
+      version = "~> 4.45.0" # Latest stable Azure provider at time of creation
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.42.0"  # For optional Kubernetes resource management
+      version = "~> 2.29.0" # For optional Kubernetes resource management
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.55.0"  # For Azure AD integration and RBAC
+      version = "~> 2.55.0" # For Azure AD integration and RBAC
     }
   }
   required_version = ">= 1.0.0"

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -22,15 +22,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.104.0" # Latest stable AWS provider at time of creation
+      version = "~> 5.39.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.42.0" # For potential future Kubernetes resource management
+      version = "~> 2.29.0"
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "~> 4.2.0" # Used for OIDC provider certificate handling
+      version = "~> 4.0.4"
     }
   }
   required_version = ">= 1.0.0"

--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -21,15 +21,15 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.50.0"  # Latest stable Google provider at time of creation
+      version = "~> 5.20.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 6.50.0"  # Used for GKE features that are in beta
+      version = "~> 5.20.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.42.0"  # For generating kubeconfig and potential future K8s resource management
+      version = "~> 2.29.0"
     }
   }
   required_version = ">= 1.0.0"

--- a/modules/iam/main.tf
+++ b/modules/iam/main.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = "~> 5.98.0"
+      version               = "~> 5.39.0"
       configuration_aliases = [aws.alternate]
     }
     azuread = {
@@ -32,11 +32,11 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.50.0"
+      version = "~> 5.20.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.42.0"
+      version = "~> 2.29.0"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.98.0"
+      version = "~> 5.39.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -25,7 +25,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.50.0"
+      version = "~> 5.20.0"
     }
   }
   required_version = ">= 1.0.0"

--- a/modules/storage/main.tf
+++ b/modules/storage/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.98.0"
+      version = "~> 5.39.0"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -14,7 +14,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.50.0"
+      version = "~> 5.20.0"
     }
   }
   required_version = ">= 1.0.0"


### PR DESCRIPTION
## Summary
- update provider version constraints to use available releases
- run `terraform fmt` across all Terraform code

## Testing
- `terraform fmt -recursive -check`
- `terraform init -backend=false` *(fails: failed to query provider packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687a599d65848325bb2868fa901a1f52